### PR TITLE
Fixed aligment for frame_4kHz

### DIFF
--- a/src/opus-1.3.1/silk/fixed/pitch_analysis_core_FIX.c
+++ b/src/opus-1.3.1/silk/fixed/pitch_analysis_core_FIX.c
@@ -172,7 +172,9 @@ opus_int silk_pitch_analysis_core(                  /* O    Voicing estimate: 0 
 
     /* Decimate again to 4 kHz */
     silk_memset( filt_state, 0, 2 * sizeof( opus_int32 ) );/* Set state to zero */
-    ALLOC( frame_4kHz, frame_length_4kHz, opus_int16 );
+    opus_int32 *tmp;
+    ALLOC( tmp, frame_length_4kHz / 2 + 1, opus_int32 );
+    frame_4kHz = (opus_int16*)tmp;
     silk_resampler_down2( filt_state, frame_4kHz, frame_8kHz, frame_length_8kHz );
 
     /* Low-pass filter */


### PR DESCRIPTION
Align frame_4kHz to 4 bytes. Which is requirement for `celt_pitch_xcorr_c`

This fixes assertion failure:
```
celt_sig_assert((((unsigned char *)_x-(unsigned char *)NULL)&3)==0);
```

Stack trace:
```
PC: 0x40100c16: celt_pitch_xcorr_c at /Users/jeffiel/Documents/Arduino/libraries/arduino-libopus/src/opus-1.3.1/celt/pitch.c line 252
EXCVADDR: 0x00000000

Decoding stack results
0x40100c13: celt_pitch_xcorr_c at /Users/jeffiel/Documents/Arduino/libraries/arduino-libopus/src/opus-1.3.1/celt/pitch.c line 252
0x4010f001: silk_burg_modified_c at /Users/jeffiel/Documents/Arduino/libraries/arduino-libopus/src/opus-1.3.1/silk/fixed/burg_modified_FIX.c line 98
0x4011366a: silk_find_LPC_FIX at /Users/jeffiel/Documents/Arduino/libraries/arduino-libopus/src/opus-1.3.1/silk/fixed/find_LPC_FIX.c line 63
0x40113fcc: silk_find_pred_coefs_FIX at /Users/jeffiel/Documents/Arduino/libraries/arduino-libopus/src/opus-1.3.1/silk/fixed/find_pred_coefs_FIX.c line 133
0x4010fbf8: silk_encode_frame_FIX at /Users/jeffiel/Documents/Arduino/libraries/arduino-libopus/src/opus-1.3.1/silk/fixed/encode_frame_FIX.c line 155
0x4010b849: silk_Encode at /Users/jeffiel/Documents/Arduino/libraries/arduino-libopus/src/opus-1.3.1/silk/enc_API.c line 499
0x4011923d: opus_encode_native at /Users/jeffiel/Documents/Arduino/libraries/arduino-libopus/src/opus-1.3.1/src/opus_encoder.c line 1846
0x40119b8b: opus_encode at /Users/jeffiel/Documents/Arduino/libraries/arduino-libopus/src/opus-1.3.1/src/opus_encoder.c line 2231
0x400d5221: audio_tools::OpusAudioEncoder::encodeFrame() at /Users/jeffiel/Documents/Arduino/libraries/arduino-audio-tools/src/AudioCodecs/CodecOpus.h line 311
0x400d5312: audio_tools::OpusAudioEncoder::write(void const*, unsigned int) at /Users/jeffiel/Documents/Arduino/libraries/arduino-audio-tools/src/AudioCodecs/CodecOpus.h line 298

```